### PR TITLE
Add context menu entry for scheduling recordings directly from epg

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -22,6 +22,10 @@ provider-name="primaeval, Chychy">
     <label>IPTV Recorder Timer</label>
     <visible>Window.isActive(tvchannels)</visible>
   </item>
+  <item library="contextEPG.py">
+    <label>Schedule IPTV Recorder</label>
+    <visible>Window.isActive(tvguide)</visible>
+  </item>
 </menu>
 </extension>
 <extension point="xbmc.service" library="server.py" start="login"/>

--- a/context.py
+++ b/context.py
@@ -1,47 +1,25 @@
-import xbmc,xbmcgui,xbmcaddon,xbmcvfs,xbmcplugin
-import sys
-import time,datetime
-import sqlite3
-import pytz
-import tzlocal
-import re
 import urllib
 
+import xbmc
+import xbmcgui
+
+
 def log(x):
-    xbmc.log(repr(x),xbmc.LOGERROR)
+    xbmc.log(repr(x), xbmc.LOGERROR)
 
-def remove_formatting(label):
-    label = re.sub(r"\[/?[BI]\]",'',label)
-    label = re.sub(r"\[/?COLOR.*?\]",'',label)
-    return label
-
-def escape( str ):
-    str = str.replace("&", "&amp;")
-    str = str.replace("<", "&lt;")
-    str = str.replace(">", "&gt;")
-    str = str.replace("\"", "&quot;")
-    return str
-
-def unescape( str ):
-    str = str.replace("&lt;","<")
-    str = str.replace("&gt;",">")
-    str = str.replace("&quot;","\"")
-    str = str.replace("&amp;","&")
-    return str
-
-window   = xbmcgui.getCurrentWindowId()
 
 channel = xbmc.getInfoLabel('ListItem.Label')
-#log(channel)
 channel = channel.decode("utf8")
 channel = channel.encode("utf8")
 channel = urllib.quote_plus(channel)
-#log(("channel",channel))
 
 try:
 
     d = xbmcgui.Dialog()
-    select = d.select("IPTV Recorder",["Add Timed Recording","Add Daily Timed Recording","Add Weekly Timed Recording","Record and Play"])
+    select = d.select("IPTV Recorder", ["Add Timed Recording",
+                                        "Add Daily Timed Recording",
+                                        "Add Weekly Timed Recording",
+                                        "Record and Play"])
 
     if select != -1:
         if select == 0:
@@ -58,5 +36,4 @@ try:
             result = xbmc.executebuiltin(cmd)
 
 except:
-    xbmcgui.Dialog().notification("IPTV Recorder","channel not found",xbmcgui.NOTIFICATION_WARNING)
-
+    xbmcgui.Dialog().notification("IPTV Recorder", "channel not found", xbmcgui.NOTIFICATION_WARNING)

--- a/contextEPG.py
+++ b/contextEPG.py
@@ -1,0 +1,66 @@
+import locale
+import time
+from datetime import datetime
+import urllib
+
+import xbmc
+import xbmcgui
+
+DATE_FORMAT = "%Y-%m-%d %H:%M:00"
+
+
+def log(x):
+    xbmc.log(repr(x), xbmc.LOGERROR)
+
+
+def escape(value):
+    value = value.decode("utf8")
+    value = value.encode("utf8")
+    return urllib.quote_plus(value)
+
+
+def get_format():
+    dateFormat = xbmc.getRegion('datelong')
+    timeFormat = xbmc.getRegion('time').replace('%H%H', '%H').replace('%I%I', '%I')
+    timeFormat = timeFormat.replace(":%S", "")
+    return "{}, {}".format(dateFormat, timeFormat)
+
+
+def extract_date(dateLabel, timeLabel):
+    date = xbmc.getInfoLabel(dateLabel)
+    timeString = xbmc.getInfoLabel(timeLabel)
+    fullDate = "{}, {}".format(date, timeString)
+
+    # https://bugs.python.org/issue27400
+    try:
+        parsedDate = datetime.strptime(fullDate, fullFormat)
+    except TypeError:
+        parsedDate = datetime(*(time.strptime(fullDate, fullFormat)[0:6]))
+    return datetime.strftime(parsedDate, DATE_FORMAT)
+
+
+fullFormat = get_format()
+language = xbmc.getLanguage()
+locale.setlocale(locale.LC_TIME, language)
+
+channel = escape(xbmc.getInfoLabel("ListItem.ChannelName"))
+title = escape(xbmc.getInfoLabel("ListItem.Label"))
+
+try:
+    start = extract_date("ListItem.StartDate", "ListItem.StartTime")
+    stop = extract_date("ListItem.EndDate", "ListItem.EndTime")
+
+    try:
+        cmd = "ActivateWindow(videos,plugin://plugin.video.iptv.recorder/record_epg/%s/%s/%s/%s,return)" % (channel,
+                                                                                                            title,
+                                                                                                            start,
+                                                                                                            stop)
+        xbmc.executebuiltin(cmd)
+
+        message = "{}: {} ({} to {})'".format(channel, title, start, stop)
+        xbmcgui.Dialog().notification("IPTV Recorder - Scheduled record", message, xbmcgui.NOTIFICATION_INFO, 10000)
+    except:
+        xbmcgui.Dialog().notification("IPTV Recorder", "Could not schedule recording", xbmcgui.NOTIFICATION_WARNING)
+except Exception as e:
+    xbmcgui.Dialog().notification("IPTV Recorder", "Error parsing dates", xbmcgui.NOTIFICATION_ERROR)
+    log("IPTV Recorder: Error parsing dates ({})".format(e))

--- a/main.py
+++ b/main.py
@@ -536,6 +536,36 @@ def record_once_time(channelid, channelname, start, stop, do_refresh=True, watch
     threading.Thread(target=record_once_thread,args=[None, do_refresh, watch, remind, channelid, channelname, start, stop, False, title]).start()
 
 
+@plugin.route('/record_epg/<channelname>/<name>/<start>/<stop>')
+def record_epg(channelname, name, start, stop):
+
+    channelname = channelname.decode("utf8")
+    name = name.decode("utf8")
+
+    start = get_utc_from_string(start.decode("utf8"))
+    stop = get_utc_from_string(stop.decode("utf8"))
+
+    log("Scheduling record for '{}: {} ({} to {})'".format(channelname, name, start, stop))
+
+    do_refresh = False
+    watch = False
+    remind = False
+    channelid = None
+    threading.Thread(target=record_once_thread,args=[None, do_refresh, watch, remind, channelid, channelname, start, stop, False, name]).start()
+
+
+def get_utc_from_string(date_string):
+    utcnow = datetime.utcnow()
+    ts = time.time()
+    utc_offset = total_seconds(datetime.fromtimestamp(ts) - datetime.utcfromtimestamp(ts))
+
+    r = re.search(r'(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):\d{2}', date_string)
+    if r:
+        year, month, day, hour, minute = r.group(1), r.group(2), r.group(3), r.group(4), r.group(5)
+        return utcnow.replace(day=int(day), month=int(month), year=int(year), hour=int(hour), minute=int(minute),
+                              second=0, microsecond=0) - timedelta(seconds=utc_offset)
+
+
 def record_once_thread(programmeid, do_refresh=True, watch=False, remind=False, channelid=None, channelname=None, start=None,stop=None, play=False, title=None):
     #TODO check for ffmpeg process already recording if job is re-added
     #channelname = urllib.unquote_plus(channelname)


### PR DESCRIPTION
I added a new context menu entry that can be used to schedule recrordings directly from IPTV Simple Client's epg. In my opinion it's sometimes easier to use the epg from IPTV Simple Client for scheduling recordings instead of the program search and full epg view in side of this plugin.

I had some troubles concerning utc offset, and date conversions and are therefore open for any feedback and improvements as there are possibly some spots I missed.

Note:
There ise currently a workaround in `contextEPG.py` in line 24   
`timeFormat = xbmc.getRegion('time').replace('%H%H', '%H').replace('%I%I', '%I')`
This is due to the following bug:  
https://github.com/xbmc/xbmc/issues/15862
