### PR TITLE
Workaround for problems when setting the locale in the EPG context menu on unix systems

### DIFF
--- a/contextEPG.py
+++ b/contextEPG.py
@@ -39,9 +39,22 @@ def extract_date(dateLabel, timeLabel):
     return datetime.strftime(parsedDate, DATE_FORMAT)
 
 
+def get_language():
+    try:
+        language = xbmc.getLanguage(xbmc.ISO_639_1, True)
+        languageParts = language.split("-")
+        return "{}_{}.UTF-8".format(languageParts[0], languageParts[1])
+    except:
+        return ""
+
+
+try:
+    usedLocale = locale.setlocale(locale.LC_TIME, get_language())
+except:
+    usedLocale = locale.setlocale(locale.LC_TIME, "")
+log("Used locale: " + usedLocale)
+
 fullFormat = get_format()
-language = xbmc.getLanguage()
-locale.setlocale(locale.LC_TIME, language)
 
 channel = escape(xbmc.getInfoLabel("ListItem.ChannelName"))
 title = escape(xbmc.getInfoLabel("ListItem.Label"))


### PR DESCRIPTION
See discussion in #25.

Added a workaround that assembles the locale from xbmc's ISO_639_1 two letter code and the region.
If this fails the system's default locale will be used.